### PR TITLE
Add styles to place blanket reporting div above ember testing container

### DIFF
--- a/blueprints/ember-cli-blanket/index.js
+++ b/blueprints/ember-cli-blanket/index.js
@@ -28,6 +28,15 @@ module.exports = {
             );
         }.bind(this))
 
+        // modify the blanket reporter styles so it's not covered by the ember testing container
+        .then(function() {
+          return this.insertIntoFile(
+              'tests/index.html',
+              '    <style>#blanket-main { position: relative; z-index: 99999; }</style>',
+              { after: '<link rel="stylesheet" href="assets/test-support.css">' + EOL }
+          );
+        }.bind(this))
+
         .then(function() {
             var fullPath = path.join(this.project.root, 'tests/blanket-options.js');
 


### PR DESCRIPTION
Prior to this commit, the blanket reports were obscured by the ember
testing container. This commit adds styles to the host application's
test/index.html that raises the blanket report div above the ember
testing container so all the blanket reports can be read.

Be happy to add a test, but seems that the deps required to run the tests were removed in c72f964?