### PR TITLE
Rename qunit-start.js to start.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,13 +54,13 @@ module.exports = {
                 destDir: '/assets'
             });
 
-            var qunitStart = this.pickFiles(lib, {
-                files: ['qunit-start.js'],
+            var start = this.pickFiles(lib, {
+                files: ['start.js'],
                 srcDir: '/',
                 destDir: '/'
             });
 
-            var testLoaderTree = this.concatFiles(this.mergeTrees([treeTestLoader, qunitStart]), {
+            var testLoaderTree = this.concatFiles(this.mergeTrees([treeTestLoader, start]), {
                 inputFiles: ['**/*.js'],
                 outputFile: '/assets/test-loader.js'
             });


### PR DESCRIPTION
Forgot this with the last PR. Need to use the new filename in the asset loader.