### PR TITLE
Remove templates from coverage

### DIFF
--- a/blueprints/ember-cli-blanket/index.js
+++ b/blueprints/ember-cli-blanket/index.js
@@ -47,7 +47,7 @@ module.exports = {
                         'blanket.options({' + EOL +
                         '   modulePrefix: "' + this.project.config().modulePrefix + '",' + EOL +
                         '   filter: "//.*' + this.project.config().modulePrefix + '\/.*/",' + EOL +
-                        '   antifilter: "//.*(tests).*/",' + EOL +
+                        '   antifilter: "//.*(tests|templates).*/",' + EOL +
                         '   loaderExclusions: []' + EOL +
                         '});'
                 )


### PR DESCRIPTION
The template code that HTMLbars creates should not be the responsibility of the Ember Dev for code coverage. 

This removes templates from blankets coverage test. 

Cheers