### PR TITLE
Guard against missing qunit when using ember-cli-mocha

### DIFF
--- a/lib/blanket-loader.js
+++ b/lib/blanket-loader.js
@@ -35,7 +35,9 @@ var blanketLoader = function(moduleName) {
 
 // Defer the start of the test run until a call to QUnit.start() this
 // allows the modules to be loaded/instrumented prior to the test run
-QUnit.config.autostart = false;
+if (typeof(QUnit) === 'object') {
+    QUnit.config.autostart = false;
+}
 
 for (moduleName in requirejs.entries) {
     if (moduleName.indexOf(blanket.options('modulePrefix')) === -1) {


### PR DESCRIPTION
When using ember-cli-mocha and following their base install instructions qunit will no longer be present
```
npm rm ember-cli-qunit --save-dev
bower uninstall --save ember-qunit
bower uninstall --save qunit
bower uninstall --save ember-qunit-notifications
```
this protects against it's abscence