### PR TITLE
Fixes #26 - conditional enablement of code coverage

### DIFF
--- a/blueprints/ember-cli-blanket/index.js
+++ b/blueprints/ember-cli-blanket/index.js
@@ -48,7 +48,8 @@ module.exports = {
                         '   modulePrefix: "' + this.project.config().modulePrefix + '",' + EOL +
                         '   filter: "//.*' + this.project.config().modulePrefix + '\/.*/",' + EOL +
                         '   antifilter: "//.*(tests|template).*/",' + EOL +
-                        '   loaderExclusions: []' + EOL +
+                        '   loaderExclusions: [],' + EOL +
+                        '   enableCoverage: true' + EOL + 
                         '});'
                 )
             }

--- a/lib/blanket-loader.js
+++ b/lib/blanket-loader.js
@@ -39,23 +39,36 @@ if (typeof(QUnit) === 'object') {
     QUnit.config.autostart = false;
 }
 
-for (moduleName in requirejs.entries) {
-    if (moduleName.indexOf(blanket.options('modulePrefix')) === -1) {
-      continue;
-    }
+var moduleLoader = function() {
+	for (moduleName in requirejs.entries) {
+		if (moduleName.indexOf(blanket.options('modulePrefix')) === -1) {
+		  continue;
+		}
 
-    // Loader exclusions are no longer necessary to fix conflicts with addon modules
-    // but may still be used to remove data coverage for specific files (e.g. config/environment).
-    var exclude = false;
-    if (blanket.options('loaderExclusions')) {
-        blanket.options('loaderExclusions').forEach(function (loaderExclusion) {
-            if (moduleName.indexOf(loaderExclusion) > -1) {
-                exclude = true;
-            }
-        });
-    }
+		// Loader exclusions are no longer necessary to fix conflicts with addon modules
+		// but may still be used to remove data coverage for specific files (e.g. config/environment).
+		var exclude = false;
+		if (blanket.options('loaderExclusions')) {
+			blanket.options('loaderExclusions').forEach(function (loaderExclusion) {
+				if (moduleName.indexOf(loaderExclusion) > -1) {
+					exclude = true;
+				}
+			});
+		}
 
-    if (!exclude) {
-        blanketLoader(moduleName);
-    }
+		if (!exclude) {
+			blanketLoader(moduleName);
+		}
+	}
+}
+
+// This could be a documented capability and move it out of blanket-loader
+// it works, can't put it in test-helper b/c it loads too late
+blanket.options('enableCoverage',window.location.search.indexOf('coverage=1') > -1);
+
+// without the above just adding/changing option value in blanket-options.js works
+// this is, of course, hijacking the blanket options namespace - so future conflicts could arise
+// hack: true
+if (blanket.options('enableCoverage')) {
+    moduleLoader();
 }


### PR DESCRIPTION
this is both a hack and working :-)  

I'll cleanup/squash etc after comments

look @ https://github.com/jschilli/ember-cli-blanket/blob/c08e7b065cc18f734e1be3262ab75c5e6659d871/lib/blanket-loader.js#L67 in particular

there are two ways of controlling this right now

it picks up the option value from blanket-options.js
```
/* globals blanket */

blanket.options({
   modulePrefix: "dummy",
   filter: "//.*dummy/.*/",
   antifilter: "//.*(tests).*/",
   loaderExclusions: [],
   enableCoverage: false
});
```

and by changing the query param `coverage` from 0->1 

we could kill line 67 altogether and leave that as an exercise to the reader.

