### PR TITLE
Resolves #18 - add in other files after tests run to get accurate covera...

### DIFF
--- a/lib/blanket-loader.js
+++ b/lib/blanket-loader.js
@@ -2,6 +2,8 @@
 
 // This could be a documented capability and move it out of blanket-loader
 // it works, can't put it in test-helper b/c it loads too late
+var savedRequire = requirejs;
+
 blanket.options('enableCoverage',window.location.search.indexOf('coverage') > -1);
 
 var blanketLoader = function(moduleName) {
@@ -45,7 +47,7 @@ if (typeof(QUnit) === 'object') {
 
 var shouldExclude = function(moduleName) {
     if (moduleName.indexOf(blanket.options('modulePrefix')) === -1) {
-      return false;
+      return true;
     }
 
     // Loader exclusions are no longer necessary to fix conflicts with addon modules
@@ -61,14 +63,13 @@ var shouldExclude = function(moduleName) {
     return exclude;
 };
 
-var savedRequire = requirejs;
 var seen = {};
 
 // proxy require to give us a chance to blanket required files
 if (blanket.options('enableCoverage')) {
     require  = function(name) {
         if (typeof(seen[name]) === 'undefined') {
-            seen[name]=true;
+            seen[name] = true;
             if (!shouldExclude(name)) {
                 blanketLoader(name);
             }
@@ -77,3 +78,23 @@ if (blanket.options('enableCoverage')) {
     };
 }
 
+/*
+ * After running all the tests we'll loop over all matching requirejs
+ * entries and annotate them so blanket will indicate their non-coverage
+ */
+moduleLoaderFinish = function() {
+  if (blanket.options('enableCoverage')) {
+    for (var moduleName in requirejs.entries) {
+      if (typeof(seen[moduleName]) === 'undefined') {
+        seen[moduleName] = true;
+        if (!shouldExclude(moduleName)) {
+          try {
+            blanketLoader(moduleName);
+          } catch (err) {
+            console.log(err);
+          }
+        }
+      }
+    }
+  }
+};

--- a/lib/start.js
+++ b/lib/start.js
@@ -52,7 +52,9 @@ else if (typeof(mocha) === 'object') {
                 });
 
                 runner.on('end', function() {
-                    blanket.onTestsDone();
+                  // annotate all files that match but were never referenced
+                  moduleLoaderFinish();
+                  blanket.onTestsDone();
                 });
 
                 runner.on('suite', function() {


### PR DESCRIPTION
arrgh - this closes the gap by covering (after the test run) any other files that should have been covered.

Hopefully this will keep folks moving while we step back and assess where this is going.

Dynamically annotating code in the browser leaves a few edge cases that are going to be tough to fix w/o hacking on other ember-cli bits (loader.js etc)

I have started toying with compile time coverage annotation - the upside is that it is super clean, the downside is that coverage testing is then an explicit act and not a browser checkbox

Oh, and this whole thing feels a bit dirty with globals popping etc