### PR TITLE
Resolves #53 remove serverMiddleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,11 +46,6 @@ module.exports = {
   testemMiddleware: function(app) {
     this.middleware(app, { root: this.project.root });
   },
-  serverMiddleware: function(options) {
-    this.app = options.app;
-    if(!this.validEnv()) { return; }
-    this.middleware(options.app, { root: this.project.root });
-  },
   postprocessTree: function(type, tree) {
     this._requireBuildPackages();
 


### PR DESCRIPTION
@sglanzer I punted on serverMiddleware altogether for now.

it's orthogonal to the original use case of file output when running ci tests

kinda maxxed on other fronts - looks like this will keep folks running