### PR TITLE
Adding an autostart option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ MIT
 
 ## Release History
 
+* 0.5.2
+
+QUnit users:
+blanket-options now includes an autostart option (default true) to control the value of QUnit.config.autostart after the code coverage instrumentation is complete
+
 * 0.5.0
 
 Thanks to monumental effort from @jschilli the project now supports reporters and headless test runs.  Additionally, unit tests are now in place with continuous integration and the code base is much cleaner.  Amazing work Jeff!

--- a/blueprints/ember-cli-blanket/files/tests/blanket-options.js
+++ b/blueprints/ember-cli-blanket/files/tests/blanket-options.js
@@ -8,7 +8,8 @@ var options = {
   enableCoverage: true,
   cliOptions: {
     reporters: ['json']
-  }
+  },
+  autostart: true
 };
 if (typeof exports === 'undefined') {
   blanket.options(options);

--- a/blueprints/ember-cli-blanket/files/tests/blanket-options.js
+++ b/blueprints/ember-cli-blanket/files/tests/blanket-options.js
@@ -7,9 +7,9 @@ var options = {
   loaderExclusions: [],
   enableCoverage: true,
   cliOptions: {
-    reporters: ['json']
-  },
-  autostart: true
+    reporters: ['json'],
+    autostart: true
+  }
 };
 if (typeof exports === 'undefined') {
   blanket.options(options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-blanket",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Blanket code coverage for ember-cli",
   "main": "index.js",
   "directories": {

--- a/vendor/blanket-require.js
+++ b/vendor/blanket-require.js
@@ -42,10 +42,6 @@ var blanketLoader = function(moduleName) {
 // Defer the start of the test run until a call to QUnit.start() this
 // allows the modules to be loaded/instrumented prior to the test run
 if (typeof(QUnit) === 'object') {
-    var autostart = QUnit.config.autostart;
-    window._$blanket_qunit = {
-      autostart: autostart
-    };
     QUnit.config.autostart = false;
 }
 

--- a/vendor/start.js
+++ b/vendor/start.js
@@ -22,7 +22,7 @@ function cliFinish() {
 blanket.onTestsDone = cliFinish;
 
 if (typeof(QUnit) === 'object') {
-QUnit.config.autostart = blanket.options('autostart');
+  QUnit.config.autostart = blanket.options('cliOptions').autostart !== false;
 }
 else if (typeof(mocha) === 'object') {
 

--- a/vendor/start.js
+++ b/vendor/start.js
@@ -22,7 +22,7 @@ function cliFinish() {
 blanket.onTestsDone = cliFinish;
 
 if (typeof(QUnit) === 'object') {
-  QUnit.config.autostart = window._$blanket_qunit.autostart;
+QUnit.config.autostart = blanket.options('autostart');
 }
 else if (typeof(mocha) === 'object') {
 


### PR DESCRIPTION
Addressing #60 by creating an autostart option in blanket-options to control the value of QUnit.config.autostart after instrumentation is complete.