### PR TITLE
Enable JSON body-parser for the coverage middleware only

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,9 +39,10 @@ module.exports = {
   },
 
   middleware: function(app, options) {
-    app.use(bodyParser.json());
-    app.use(coverageMiddleware(options));
-    app.use(logErrors);
+    app.post('/write-blanket-coverage',
+             bodyParser.json(),
+             coverageMiddleware(options),
+             logErrors);
   },
   testemMiddleware: function(app) {
     this.middleware(app, { root: this.project.root });

--- a/lib/coverage-middleware.js
+++ b/lib/coverage-middleware.js
@@ -33,13 +33,8 @@ module.exports = function(options) {
   var blanketOptions = loadBlanketOptions(options);
   var reporter = loadReporter(blanketOptions);
 
-  return function(req, res, next) {
-    // TODO: optionize url
-    if (req.method === 'POST' && req.url === '/write-blanket-coverage') {
-      reporter.report(req.body);
-      res.status(200).send('all good');
-    } else {
-      next();
-    }
+  return function(req, res) {
+    reporter.report(req.body);
+    res.status(200).send('all good');
   };
 };


### PR DESCRIPTION
Globally using the `bodyParser.json()` for an application causes any requests
with content-length > 0 to break when using `ember server --proxy ...`, the
usual symptom being that GET and DELETE requests work, but POST and PUT
requests fail:

```
Error proxying to http://192.168.2.10:9900
socket hang up
Error: socket hang up
   at createHangUpError (_http_client.js:215:15)
   at Socket.socketCloseListener (_http_client.js:247:23)
   at Socket.emit (events.js:129:20)
   at TCP.close (net.js:476:12)
```

Restricting the body parser only to the path which the coverage middleware
handles resolves this problem.