### PR TITLE
Fix #68 by re-enabling serverMiddleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,11 @@ module.exports = {
   testemMiddleware: function(app) {
     this.middleware(app, { root: this.project.root });
   },
+  serverMiddleware: function(options) {
+    this.app = options.app;
+    if(!this.validEnv()) { return; }
+    this.middleware(options.app, { root: this.project.root });
+  },
   postprocessTree: function(type, tree) {
     this._requireBuildPackages();
 


### PR DESCRIPTION
The serverMiddleware had been disabled because of problems when using
a http-proxy or ember-cli's proxy middleware (see #53 and #46).

Since the root cause has been resolved in #66, there's no need to hold
back this feature any longer.

This reverts commit 9b63dfd3dbf6a469fca3cf810630536d7062ee71.