### PR TITLE
Fix renamer, lcov check was not accessing the proper object

### DIFF
--- a/lib/reporters/lcov-reporter.js
+++ b/lib/reporters/lcov-reporter.js
@@ -1,13 +1,13 @@
 var Reporter = require('../reporter');
 
 var lcovRecord = function(data) {
-  var str = "",
+  var str = '',
       lineHandled = 0,
       lineFound = 0,
       fileName = data.fileName;
 
-  if(this.options.lcovOptions && this.options.lcovOptions.renamer){
-    fileName = this.options.lcovOptions.renamer(fileName);
+  if (this.options.cliOptions && this.options.cliOptions.lcovOptions && this.options.cliOptions.lcovOptions.renamer){
+    fileName = this.options.cliOptions.lcovOptions.renamer(fileName);
   }
 
   str += 'SF:' + fileName + '\n';

--- a/tests/unit/reporters/lcov-reporter-test.js
+++ b/tests/unit/reporters/lcov-reporter-test.js
@@ -14,9 +14,11 @@ describe('LCOV Reporter', function() {
   it('should replace modules names with file names when requested', function () {
     var expectedOutput = fs.readFileSync(path.join(__dirname, '../../fixtures/lcov-output-with-renamer.dat'), 'utf8');
     var reporter = new LCOVReporter({
-      lcovOptions: {
-        renamer: function(moduleName){
-          return moduleName.replace(/^todomvc-ember-cli/, 'something-else');
+      cliOptions: {
+        lcovOptions: {
+          renamer: function (moduleName) {
+            return moduleName.replace(/^todomvc-ember-cli/, 'something-else');
+          }
         }
       }
     });


### PR DESCRIPTION
#67 contained a typo that prevents the renamer from actually working.  This PR fixes that issue to help enable #63