### PR TITLE
Document the use of the ember-cli --test-page option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,15 @@ var options = {
 
 Only a single reporter is supported currently.
 
-Append ```?coverage``` to the HTML report URL to enable coverage. This option will enable the creation of the coverage data file when running within a continuous integration context. This value can be specified within the testem.json:
+Append ```?coverage``` to the HTML report URL to enable coverage. This option will enable the creation of the coverage data file when running within a continuous integration context. 
+
+You can add this as part of the ```ember test``` command for a single run:
+
+```bash
+ember test --test-page='tests/index.html?coverage'
+```
+
+or it can be specified within testem.json for use everytime you test:
 
 ```js
 {


### PR DESCRIPTION
The option to specify a --test-page for ember-cli was added in https://github.com/ember-cli/ember-cli/pull/4377.  I took a shot at documenting this here.  

I put the options in this order because it seemed like the easiest way to test this out would be to run it one off.  I'm happy to switch them around and indicate testem.json modification first.  I'm not particularly good at writing docs (or really anything for that matter), so don't hesitate to slam my grammar and I will fix it up.

This should probably wait to be merged until ember-cli 0.2.8 is released, but I figured this would be a nice placeholder until then.  I didn't want to clutter up the readme with a 'if you're using ember-cli >= v0.2.8' statement, but let me know if that seems like a better path.

