### PR TITLE
Document the coverage POST request

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,28 @@ It should be noted that given the multitude of transformations that the javascri
 
 In fact, there is current no direct mapping between the `es6` module names in the lcov output and the original input files.
 
+### Reporters and Testing Mocks
+
+When tests are complete an HTTP POST request is sent to the ember-cli express server to initiate the report writing process.  This request may get intercepted if you are using a mocking library like ember-cli-mirage or Pretender.  You will need to configure these libraries to "passthrough" the request.  
+
+If you are using Pretender directly add
+```js
+this.post(
+  '/write-blanket-coverage',
+  this.passthrough
+);
+```
+
+For ember-cli-mirage add this to your config.js
+
+```js
+this.pretender.post.call(
+  this.pretender,
+  '/write-blanket-coverage',
+  this.pretender.passthrough
+);
+```
+
 ## Usage
 
 Run `ember server`, navigate to the application url [/tests](http://localhost:4200/tests) (e.g. localhost:4200/tests) and select the "Enable coverage" checkbox.


### PR DESCRIPTION
Pretender catches every HTTP request sent sometimes without any error message.  This is pretty annoying if you don’t know where to look for why the coverage report is being sporadically created.  This is pretty tangential information and normally wouldn't belong in the docs for the library however I hope it will be included for two reasons.

  1.  It's not intuitively obvious that writing a coverage report would need to send an HTTP request so it's pretty hard to reason about why this would be failing in this way.
  
  2.  I spent something like 15 hours tracking this down and the fix was only a single line in my app code so I will feel better about myself if I get to add some documentation as well.