### PR TITLE
Move blanket into bower's devDependencies.

### DIFF
--- a/blueprints/ember-cli-blanket/index.js
+++ b/blueprints/ember-cli-blanket/index.js
@@ -6,7 +6,7 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('blanket', '~1.1.5')
+    return this.addBowerPackageToProject('blanket', '~1.1.5', {saveDev: true})
 
         // Modify tests/index.html to include the blanket options after the application
         .then(function() {


### PR DESCRIPTION
I noticed blanket currently gets put into bower's dependencies. Since it's only used for unit tests, it seems like it makes more sense to put it into devDependencies.