### PR TITLE
Fix so null reporter builds again.

### DIFF
--- a/lib/reporters/null-reporter.js
+++ b/lib/reporters/null-reporter.js
@@ -7,5 +7,7 @@ var Reporter = require('../reporter');
  */
 module.exports = Reporter.extend({
   report: function(/* coverageData */) {
+  },
+  processOptions: function(/* options */) {
   }
 });


### PR DESCRIPTION
Null reporter wouldn't build because it was using the base Reporter's processOptions, which was expecting an outputFile be specified.