### PR TITLE
Increase the file size limit for /write-blanket-coverage

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = {
 
   middleware: function(app, options) {
     app.post('/write-blanket-coverage',
-             bodyParser.json(),
+             bodyParser.json({ limit: '50mb' }),
              coverageMiddleware(options),
              logErrors);
   },


### PR DESCRIPTION
We have a large repo and when it tries to make this request it fails with a 413 status code. Increasing the limit fixes this issue and I think 50mb should be sufficient for even the biggest of repositories.