### PR TITLE
Resolve "Could not find module" error when used in an Ember CLI Addon

### DIFF
--- a/vendor/blanket-require.js
+++ b/vendor/blanket-require.js
@@ -50,6 +50,10 @@ var shouldExclude = function(moduleName) {
       return true;
     }
 
+    if ( moduleName === blanket.options('modulePrefix') ) {
+        return true;
+    }
+
     // Loader exclusions are no longer necessary to fix conflicts with addon modules
     // but may still be used to remove data coverage for specific files (e.g. config/environment).
     var exclude = false;


### PR DESCRIPTION
When an addon is built a module is defined with the < addon name > that has a dependency named the name of the module plus the text of "/index" (ie. `< addon name >/index`), such as in the following:

```
define('sl-ember-components', ['sl-ember-components/index', 'ember', 'exports'], function(__index__, __Ember__, __exports__) {
  'use strict';
  var keys = Object.keys || __Ember__['default'].keys;
  var forEach = Array.prototype.forEach && function(array, cb) {
    array.forEach(cb);
  } || __Ember__['default'].EnumerableUtils.forEach;

  forEach(keys(__index__), (function(key) {
    __exports__[key] = __index__[key];
  }));
});
```

This dependency does not actually exist, which then causes the following error to be thrown in the console from the ember-cli/loader.js package:

`Error: Could not find module "sl-ember-components/index" imported from "sl-ember-components(…)"`

I initially attempted to add an entry for this module in the `loaderExclusions` entry in the config file as discussed in the related https://github.com/sglanzer/ember-cli-blanket/issues/14, but due to the fact that `shouldExclude()` in `vendor/blanket-require.js` uses `indexOf()` the correct combination can never be achieved to catch this undesired module name.

Therefore I have added an additional check for this specific condition which compares the module name created in this situation, < addon name >, against the blanket.options('modulePrefix') and if they match the/this module should be excluded.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sglanzer/ember-cli-blanket/83)
<!-- Reviewable:end -->
