### PR TITLE
Fix tests redirecting from "/tests" to "/?grep=..."

### DIFF
--- a/vendor/start.js
+++ b/vendor/start.js
@@ -91,15 +91,7 @@ else if (typeof(mocha) === 'object') {
                 originalReporter.apply(this, [runner]);
             };
 
-
-        // From mocha.js HTML reporter
-        blanketReporter.prototype.suiteURL = function(suite){
-          return '?grep=' + encodeURIComponent(suite.fullTitle());
-        };
-
-        blanketReporter.prototype.testURL = function(test){
-          return '?grep=' + encodeURIComponent(test.fullTitle());
-        };
+        blanketReporter.prototype = originalReporter.prototype;
 
         mocha.reporter(blanketReporter);
     })();


### PR DESCRIPTION
Fixes switchfly/ember-cli-mocha#61

> When I run my tests in the browser (by visiting localhost:4200/tests?coverage=true), everything works fine, but if I try to click on one of the links reported by mocha (to view that specific set of tests), the browser redirects me back to "/?grep=".

> I did a little inspecting of the HTML on the mocha test results page, and it looks like the links are being created as "href=?grep=", but I believe the correct link should be "href=/tests?grep=".

This happens when using ember-cli-mocha + ember-cli-blanket.

This was fixed by mochajs/mocha@221e0360e23a41e4b8583a22a7a5f3a3aa5f55cb and in all these related projects:
* alex-seville/blanket#356
* switchfly/ember-mocha#11
* switchfly/ember-cli-mocha#20