### PR TITLE
Make LCOV reporter compatible with Coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,20 @@ var options = {
     branchTracking: true,
     cliOptions: {
       jsonOptions: {
-        outputFile: 'test-output.json' // default is 'coverage.json'
+        // output file name relative to project's root dir, default is 'coverage.json'
+        outputFile: 'test-output.json'
       },
       lcovOptions: {
         outputFile: 'lcov.dat',
-        //provide a function to rename es6 modules to a file path
+        
+        // automatically skip missing files, relative to project's root dir
+        excludeMissingFiles: true, // default false
+        
+        // provide a function to rename es6 modules to a file path
         renamer: function(moduleName){
+          // return a falsy value to skip given module
+          if (moduleName === 'unwanted') { return; }
+        
           var expression = /^APP_NAME/;
           return moduleName.replace(expression, 'app') + '.js';
         }

--- a/lib/reporters/lcov-reporter.js
+++ b/lib/reporters/lcov-reporter.js
@@ -1,4 +1,5 @@
 var Reporter = require('../reporter');
+var fs       = require('fs');
 
 var lcovRecord = function(data) {
   var str = '',
@@ -8,6 +9,18 @@ var lcovRecord = function(data) {
 
   if (this.options.cliOptions && this.options.cliOptions.lcovOptions && this.options.cliOptions.lcovOptions.renamer){
     fileName = this.options.cliOptions.lcovOptions.renamer(fileName);
+  }
+
+  // Skip entries with falsy filenames -- lets ignoring files from renamer
+  if (!fileName) { return; }
+
+  // Skip non-existent files if lcovOptions.excludeMissingFiles is set
+  if (this.options.cliOptions && this.options.cliOptions.lcovOptions && this.options.cliOptions.lcovOptions.excludeMissingFiles){
+    try {
+      fs.accessSync(fileName, fs.F_OK);
+    } catch (e) {
+      return;
+    }
   }
 
   str += 'SF:' + fileName + '\n';


### PR DESCRIPTION
The [node-coveralls](https://github.com/nickmerwin/node-coveralls) would crash if the report references a missing file.

So I've added a `excludeMissingFiles` option that would prevent files not existing within project's root folder from making their way into the report.

Also, returning a falsy value from the `renamer` callback would also prevent that file from appearing in the report.

PS Line numbers are still off, is this a fundamental LCOV flaw?