### PR TITLE
ember-cli-mirage does not need passthrough post 0.2.0-beta.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ this.post(
 );
 ```
 
-For ember-cli-mirage add this to your config.js
+For versions of ember-cli-mirage before 0.2.0-beta.2 add this to your config.js
 
 ```js
 this.pretender.post.call(


### PR DESCRIPTION
With [ember-cli-mirage#281](https://github.com/samselikoff/ember-cli-mirage/pull/281) mirage shuts down its server at the end of each test.

This config should no longer be needed for apps using latest `ember-cli-mirage` and the `destroyApp` helper.

Tested on a newly created app.