### PR TITLE
Add version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ ember install:addon ember-cli-blanket
 ```
 
 ## Requirements
-* If using Mocha, Testem `>= 1.6.0` for which you need ember-cli `> 2.4.3`
 * If using Mirage you need `ember-cli-mirage >= 0.1.13`
 * If using Pretender (even as a dependency of Mirage) you need `pretender >= 0.11.0`
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ ember install ember-cli-blanket
 ember install:addon ember-cli-blanket
 ```
 
+## Requirements
+* If using Mocha, Testem `>= 1.6.0` for which you need ember-cli `> 2.4.3`
+* If using Mirage you need `ember-cli-mirage >= 0.1.13`
+* If using Pretender (even as a dependency of Mirage) you need `pretender >= 0.11.0`
+
 ## Reporters
 
 ember-cli-blanket can output coverage data to a file.


### PR DESCRIPTION
Took these from ember-cli-code-coverage. Seems to be relevant here too, as I was unable to get reports generated until I updated to these versions. Resolves #157 