### PR TITLE
Fixing #159.

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,10 +75,11 @@ module.exports = {
   postprocessTree: function(type, tree) {
     this._requireBuildPackages();
     var checker = new VersionChecker(this);
-    var testLoaderFile = checker.for('ember-cli', 'npm').satisfies('>= 2.7.0') ? 'tests.js' : 'test-loader.js';
+    var isNpmTestLoader = checker.for('ember-cli', 'npm').satisfies('>= 2.7.0');
+    var testLoaderFile = isNpmTestLoader ? 'tests.js' : 'test-loader.js';
     if (type === 'all' && this.app.tests) {
       var treeTestLoader = new Funnel(tree, {
-        files: [testLoaderFile],
+        files: isNpmTestLoader ? [testLoaderFile, 'tests.map'] : [testLoaderFile], // don't loose the sourcemaps
         srcDir: 'assets',
         destDir: 'app'
       });


### PR DESCRIPTION
With ember-cli >= 2.7 we have to take care to not drop the sourcemaps (tests.map). 

I'm definitely open to feedback on this. There might be a more elegant solution than explicitly including the `tests.map` file, such as restructuring the trees. I went with this solution because it was easy and seems low risk. 