### PR TITLE
Added project deprecation warning to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DEPRECATED
 
-This project is no longer maintained, [Ember CLI Code Coverage](https://github.com/kategengler/ember-cli-code-coverage) is the recommended replacement.
+This project is no longer actively maintained, [Ember CLI Code Coverage](https://github.com/kategengler/ember-cli-code-coverage) is the recommended replacement.
 
 [![npm](https://img.shields.io/npm/v/ember-cli-blanket.svg)](https://www.npmjs.com/package/ember-cli-blanket)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DEPRECATED
+
+This project is no longer maintained, [Ember CLI Code Coverage](https://github.com/kategengler/ember-cli-code-coverage) is the recommended replacement.
+
 [![npm](https://img.shields.io/npm/v/ember-cli-blanket.svg)](https://www.npmjs.com/package/ember-cli-blanket)
 
 Ember-cli-blanket


### PR DESCRIPTION
As this project is no longer being maintained in favor of ember-cli-code-coverage, I added a deprecation warning to the top of the README to inform other developers.